### PR TITLE
Use rioxarray

### DIFF
--- a/src/landsat_importer/landsat_89_metadata.py
+++ b/src/landsat_importer/landsat_89_metadata.py
@@ -79,6 +79,17 @@ def get_cloud_shadow_confidence():
 def get_cirrus_confidence():
     return lambda q: (q >> 14) & 3
 
+product_info = {
+    'https://doi.org/10.5066/P975CC9B': {
+        'title': 'Landsat 8-9 Operational Land Imager and Thermal Infrared Sensor Collection 2 Level-1 Data',
+        'summary': 'Landsat 8-9 Operational Land Imager (OLI) and Thermal Infrared Sensor (TIRS) Collection 2 Level-1 15- to 30-meter multispectral data.',
+        },
+    'https://doi.org/10.5066/P9OGBGM6': {
+        'title': 'Landsat 8-9 OLI/TIRS Collection 2 Level-2 Science Products',
+        'summary': 'Landsat 8-9 Operational Land Imager (OLI) and Thermal Infrared (TIRS) Collection 2 Level-2 Science Products 30-meter multispectral data.',
+        }
+    }
+
 
 class Landsat89Metadata(LandsatMetadata):
 
@@ -140,6 +151,16 @@ class Landsat89Metadata(LandsatMetadata):
 
         self.product_id = self["LANDSAT_METADATA_FILE/PRODUCT_CONTENTS/LANDSAT_PRODUCT_ID"]
         self.scene_id = self["LANDSAT_METADATA_FILE/LEVEL1_PROCESSING_RECORD/LANDSAT_SCENE_ID"]
+        self.doi = self['LANDSAT_METADATA_FILE/PRODUCT_CONTENTS/DIGITAL_OBJECT_IDENTIFIER']
+        try:
+            self.title = product_info[self.doi]['title']
+            self.summary = product_info[self.doi]['summary']
+        except KeyError:
+            self.title = f'{self.spacecraft_id} {self.processing_level} data'
+            self.summary = ''
+            pass
+        self.acknowledgement = self['LANDSAT_METADATA_FILE/PRODUCT_CONTENTS/ORIGIN']
+        self.software_l1 = self['LANDSAT_METADATA_FILE/LEVEL1_PROCESSING_RECORD/PROCESSING_SOFTWARE_VERSION']
 
         if self.processing_level.startswith("L1"):
             self.level = 1
@@ -147,6 +168,7 @@ class Landsat89Metadata(LandsatMetadata):
         elif self.processing_level.startswith("L2SP"):
             self.level = 2
             oli_bands = [str(b) for b in range(1,8)] # OLI bands are 1-7
+            self.software_l2 = self['LANDSAT_METADATA_FILE/LEVEL2_PROCESSING_RECORD/PROCESSING_SOFTWARE_VERSION']
         else:
             raise Exception("Unsupported processing level %s" % self.processing_level)
 

--- a/src/landsat_importer/landsat_89_metadata.py
+++ b/src/landsat_importer/landsat_89_metadata.py
@@ -238,6 +238,9 @@ class Landsat89Metadata(LandsatMetadata):
             self.standard_names["10"] = "toa_brightness_temperature"
             self.standard_names["11"] = "toa_brightness_temperature"
 
+            self.long_names[self.get_qa_band()] = 'QA Band'
+            self.standard_names[self.get_qa_band()] = 'quality_flag'
+
         # for input bands identified by a number, prepend "B" to provide the output name
         for numeric_band in numeric_bands:
             self.names[numeric_band] = "B" + numeric_band

--- a/src/landsat_importer/landsat_89_metadata.py
+++ b/src/landsat_importer/landsat_89_metadata.py
@@ -261,12 +261,10 @@ class Landsat89Metadata(LandsatMetadata):
 
     def get_reflectance_correction(self,band):
         # return (add,mult,sun_elevation)
-        root = "L1_METADATA_FILE/RADIOMETRIC_RESCALING"
-        add = self[root+"/REFLECTANCE_ADD_BAND_%s" % band]
-        mult = self[root+"/REFLECTANCE_MULT_BAND_%s" % band]
+        add = self[f'LANDSAT_METADATA_FILE/LEVEL1_RADIOMETRIC_RESCALING/REFLECTANCE_ADD_BAND_{band}']
+        mult = self[f'LANDSAT_METADATA_FILE/LEVEL1_RADIOMETRIC_RESCALING/REFLECTANCE_MULT_BAND_{band}']
+        sun_elevation = self['LANDSAT_METADATA_FILE/IMAGE_ATTRIBUTES/SUN_ELEVATION']
 
-        root = "LANDSAT_METADATA_FILE/IMAGE_ATTRIBUTES"
-        sun_elevation = self[root+"/SUN_ELEVATION"]
         if add is None or mult is None:
             raise Exception("get_reflectance_correction")
         else:

--- a/src/landsat_importer/netcdf4_exporter.py
+++ b/src/landsat_importer/netcdf4_exporter.py
@@ -23,6 +23,7 @@ import os
 import getpass
 import datetime
 import xarray as xr
+from pyproj import Transformer
 import numpy as np
 import json
 import logging
@@ -59,27 +60,32 @@ class Netcdf4Exporter:
         self.logger = logging.getLogger("Netcdf4Exporter")
 
 
-    def export(self,input_path, lats, lons, output_layers, to_path, bounds, include_angles=False,history="",shrink=False):
+    def export(self,input_path, dataset, bands, to_path, history=""):
         """
         Export an imported scene
 
         Args:
             input_path: the path to the input scene
-            lats: 2d array of latitudes for each pixel
-            lons: 2d array of longitudes for each pixel
-            output_layers: list of (band,array) pairs for each layer to export
+            dataset: xarray dataset containing the scene to export
+            bands: list of bands in the dataset
             to_path: the path to which netcdf4 data is to be exported
-            bounds: tuple of form ((min_lat,min_lon),(max_lat,max_lon))
-            include_angles: whether to include simulated SAA,SZA,VAA,VZA (applicable for collection 1)
             history: string to supply the processing history to add to global metadata
-            shrink: whether to shrink the exported data to include the area described in the bounds parameter
         """
-        dataset = xr.Dataset()
 
-        nlat = lats.shape[0]
-        nlon = lats.shape[1]
+        dataset = dataset.expand_dims('time')
+        dataset = dataset.rio.write_coordinate_system()
 
-        ((min_lat,min_lon),(max_lat,max_lon)) = bounds
+        nmap = {b:self.landsat_metadata.get_name(b) for b in bands}
+        dataset = dataset.rename(nmap)
+
+        # Calculate pixel longitude, latitudes.
+        # Do this after the scene has been clipped.
+        self.logger.info("Computing lat/lon mapping")
+        transformer = Transformer.from_crs(dataset.spatial_ref.projected_crs_name, "EPSG:4326")
+        lat, lon = transformer.transform(*np.meshgrid(dataset.x, dataset.y))
+        dataset['lat'] = ('y', 'x'), lat, {'standard_name':'latitude',  'units':'degrees_north'}
+        dataset['lon'] = ('y', 'x'), lon, {'standard_name':'longitude', 'units':'degrees_east'}
+        self.logger.info("Starting Netcdf4 Export")
 
         dataset.attrs['landsat_importer_version'] = LANDSAT_IMPORTER_VERSION
         dataset.attrs['source_file'] = os.path.split(input_path)[-1]
@@ -95,6 +101,9 @@ class Netcdf4Exporter:
         dataset.attrs['processing_level'] = str(self.landsat_metadata.get_processing_level())
         dataset.attrs['collection'] = np.int32(self.landsat_metadata.collection)
 
+        # Get the bounding box. Note this includes the pixel edges, so will be half
+        # a pixel larger than the outermost lat/lon positions
+        min_lon, min_lat, max_lon, max_lat = dataset.rio.transform_bounds('EPSG:4326')
         dataset.attrs["geospatial_lat_min"] = min_lat
         dataset.attrs["geospatial_lon_min"] = min_lon
         dataset.attrs["geospatial_lat_max"] = max_lat
@@ -102,8 +111,10 @@ class Netcdf4Exporter:
         dataset.attrs["geospatial_lat_units"] = "degrees_north"
         dataset.attrs["geospatial_lon_units"] = "degrees_east"
 
-        # dataset.attrs["geospatial_lat_resolution"] = "%d m" % round(resolution_m_lat)
-        # dataset.attrs["geospatial_lon_resolution"] = "%d m" % round(resolution_m_lon)
+        # rio.resolution maybe negative depending on direction of coordinate grid
+        res = [round(abs(i)) for i in dataset.rio.resolution()]
+        dataset.attrs["geospatial_lat_resolution"] = f'{res[1]} {dataset.y.units}'
+        dataset.attrs["geospatial_lon_resolution"] = f'{res[0]} {dataset.x.units}'
         # dataset.attrs["spatial_resolution"] = "%d m" % round((resolution_m_lat + resolution_m_lon) * 0.5)
 
         dataset.attrs["cdm_data_type"] = "grid"
@@ -127,121 +138,43 @@ class Netcdf4Exporter:
         ecomp = {'zlib': True, 'complevel': 5}
         encodings = {"time": {"units": "seconds since 1978-01-01"}}
 
-        dataset["lat"] = xr.DataArray(data=lats, dims=('nj', 'ni'),
-                                      attrs={"units": 'degrees_north', "standard_name": "latitude"})
-        dataset["lon"] = xr.DataArray(data=lons, dims=('nj', 'ni'),
-                                      attrs={"units": 'degrees_east', "standard_name": "longitude"})
         encodings['lat'] = ecomp
         encodings['lon'] = ecomp
 
-        for (band, data) in output_layers:
+        for band in bands:
             # get metadata to write into the exported variable attributes
             # should be empty string if not relevant or CF-compliant string if applicable
-            units = self.landsat_metadata.get_units(band)
-            standard_name = self.landsat_metadata.get_standard_name(band)
-            comment = self.landsat_metadata.get_comment(band)
             band_name = self.landsat_metadata.get_name(band)
-            long_name = self.landsat_metadata.get_long_name(band)
 
             if self.landsat_metadata.is_integer(band):
-                data = data.astype(int)
                 encodings[band_name] = {'dtype': 'int32', "_FillValue": -999}
             else:
                 encodings[band_name] = {'dtype':'float32'}
 
             encodings[band_name].update(ecomp)
 
-            data = np.expand_dims(data, axis=0)
 
             # where QA_PIXEL bit 0 is set there is no data.  convert to NaN to make it easier for downstream processing to handle
-            if band == self.landsat_metadata.get_qa_band():
-                data = np.where(data == 1, np.nan, data)
 
-            dataset[band_name] = xr.DataArray(data=data, dims=("time", "nj", "ni"))
-
-            if units:
-                dataset[band_name].attrs["units"] = units
-
-            if standard_name:
-                dataset[band_name].attrs["standard_name"] = standard_name
-
-            if long_name:
-                dataset[band_name].attrs["long_name"] = long_name
-
-            if comment:
-                dataset[band_name].attrs["comment"] = comment
+            dataset[band_name].attrs['coordinates'] = 'lon lat'
 
             if band == self.landsat_metadata.get_qa_band():
                 (flag_masks, flag_values, flag_meanings) = self.landsat_metadata.get_qa_flag_metadata()
                 # Output datatype may be modified via the encodings dictionary, so
                 # need to check both encodings and current array to get correct type
-                flag_type = encodings[band_name].get('dtype') or data.dtype
+                flag_type = encodings[band_name].get('dtype') or dataset[band_name].dtype
                 dataset[band_name].attrs["flag_values"] = np.array(flag_values, flag_type)
                 dataset[band_name].attrs["flag_masks"] = np.array(flag_masks, flag_type)
                 # Convert flag meanings into valid CF attribute
                 dataset[band_name].attrs["flag_meanings"] = ' '.join(s.replace(' ', '_') for s in flag_meanings)
 
 
-        if include_angles and self.landsat_metadata.get_collection() == 1:
-            # for collection 2, angles should already be included via bands SAA,SZA,VAA,VZA converted from TIFFs
-            # for collection 1, need to create equivalent but constant per-pixel angles from the metadata
-            for name in ["satellite_zenith_angle","relative_azimuth_angle"]:
-                da = self.create_dummy_angles(nlat,nlon)
-                da.attrs["units"] = "degree"
-                if name == "satellite_zenith_angle":
-                    da.attrs["long_name"] = "satellite zenith angle"
-                    da.attrs["standard_name"] = "sensor_zenith_angle"
-                    da.attrs["comment"] = "The satellite zenith angle at the time of the observations"
-                elif name == "relative_azimuth_angle":
-                    da.attrs["long_name"] = "satellite azimuth angle"
-                    da.attrs["standard_name"] = "sensor_azimuth_angle"
-                    da.attrs["comment"] = "The relative azimuth angle at the time of the observations"
-                dataset[name] = da
-                encodings[name] = {'dtype': 'float32'}
-                encodings[name].update(ecomp)
-            zen, az, dist = self.landsat_metadata.get_solar_angles()
-            da = self.create_dummy_angles(nlat, nlon, zen)
-            da.attrs = dict(
-                long_name='solar zenith angle',
-                standard_name='solar_zenith_angle',
-                units='degree'
-                )
-            dataset['solar_zenith_angle'] = da
-            encodings['solar_zenith_angle'] = {'dtype': 'float32'}
-            encodings['solar_zenith_angle'].update(ecomp)
-            da = self.create_dummy_angles(nlat,nlon, az)
-            da.attrs = dict(
-                long_name='solar azimuth angle',
-                standard_name='solar_azimuth_angle',
-                units='degree'
-                )
-            dataset['solar_azimuth_angle'] = da
-            encodings['solar_azimuth_angle'] = {'dtype': 'float32'}
-            encodings['solar_azimuth_angle'].update(ecomp)
-
         dataset["time"] = xr.DataArray(data=np.array([self.landsat_metadata.get_acquisition_timestamp()],dtype='datetime64[ns]'), dims=('time'),
                                       attrs={"standard_name": "time", "long_name":"reference time of observations"})
-
-
-        if shrink:
-            self.logger.info(f"Shrinking output to box lon: {min_lon} - {max_lon}, lat: {min_lat} - {max_lat}")
-            mask_lon = dataset.lon.where((dataset.lon >= min_lon) & (dataset.lon <= max_lon))
-            mask_lat = dataset.lat.where((dataset.lat >= min_lat) & (dataset.lat <= max_lat))
-            combined_mask_lat = mask_lat.where(~np.isnan(mask_lon))
-            combined_mask_lon = mask_lon.where(~np.isnan(mask_lat))
-            njs = [int(combined_mask_lat.argmin(...)["nj"]),int(combined_mask_lat.argmax(...)["nj"])]
-            nis = [int(combined_mask_lon.argmin(...)["ni"]),int(combined_mask_lon.argmax(...)["ni"])]
-            dataset = dataset.isel(nj=slice(min(njs),max(njs)),ni=slice(min(nis),max(nis)))
 
 
         dataset.to_netcdf(to_path, encoding=encodings)
         self.logger.info("Netcdf4 Export complete to %s" % to_path)
 
 
-    def create_dummy_angles(self, nlat, nlon, fill_value=None):
-        if fill_value is None:
-            data = np.zeros((1, nlat, nlon), np.float32)
-        else:
-            data = np.full((1, nlat, nlon), fill_value, np.float32)
-        return xr.DataArray(data=data, dims=("time", "nj", "ni"))
 

--- a/src/landsat_importer/processor.py
+++ b/src/landsat_importer/processor.py
@@ -187,8 +187,7 @@ class Processor:
         if landsat_metadata.is_level2(band):
             add = landsat_metadata.get_level2_shift(band)
             mult = landsat_metadata.get_level2_scale(band)
-            fill = landsat_metadata.get_level2_fillvalue(band)
-            return TiffImporter.decode(data, mult, add, fill)
+            return TiffImporter.decode(data, mult, add, None)
         else:
             if landsat_metadata.is_reflectance(band) or landsat_metadata.is_corrected_reflectance(band):
                 A_rho, M_rho, sun_elevation = landsat_metadata.get_reflectance_correction(band)

--- a/src/landsat_importer/tiff_importer.py
+++ b/src/landsat_importer/tiff_importer.py
@@ -24,7 +24,7 @@ import math
 import rioxarray
 import xarray as xr
 from pyproj import Transformer
-import rasterio
+
 
 class TiffImporter:
 
@@ -49,17 +49,18 @@ class TiffImporter:
         """
         Open the TIFF file and store in an array.
         """
-        object_image = rasterio.open(path).read(1)
+        da = rioxarray.open_rasterio(path).squeeze(drop=True)
         if band == "8":
-            array_image = np.array(object_image[::2, ::2])
-        else:
-            array_image = np.array(object_image)
+            da = da[::2, ::2]
 
-        if is_int:
-            array_image = array_image.astype(int)
+        if '_FillValue' in da.attrs:
+            da = da.where(da != da._FillValue)
+        elif is_int:
+            da = da.astype(int)
         else:
-            array_image = array_image.astype(float)
-        return array_image
+            da = da.astype(float)
+
+        return da
 
     @staticmethod
     def DN_to_refl(image_data, M_ro, A_ro):

--- a/src/landsat_importer/tiff_importer.py
+++ b/src/landsat_importer/tiff_importer.py
@@ -50,17 +50,18 @@ class TiffImporter:
         Open the TIFF file and store in an array.
         """
         da = rioxarray.open_rasterio(path).squeeze(drop=True)
+        encoding = da.encoding
         if band == "8":
             da = da[::2, ::2]
 
         if '_FillValue' in da.attrs:
             da = da.where(da != da._FillValue)
         elif is_int:
-            da = da.astype(int)
+            da = da.astype(np.int32)
         else:
-            da = da.astype(float)
+            da = da.astype(np.float32)
 
-        return da
+        return da, encoding
 
     @staticmethod
     def DN_to_refl(image_data, M_ro, A_ro):


### PR DESCRIPTION
### Use rioxarray to read Landsat data directly
Using rioxarray allows us to read the landsat data directly to a DataArray object with all the correct crs and projection information (including projection_x/y_coordinate and grid_mapping text) allowing us to write CF compliant output much more easily. The previously version was already using rioxarray to read the projection transform needed to calculate per-pixel latitude/longitude, so we don't have an extra dependency

The requested bands are combined into a Dataset object within processor.py (previously this was only done in the exporter). We can now perform any spatial clipping **before** calculating per-pixel latitude longitudes - this greatly reduces the processing time when extracting a small bounding box

geospatial_lat/lon_min/max attributes are set from the bounding box. This means they now include the edges of the pixels (previous bounding box was based on pixel centres)

Output L1c includes correct x and y coordinates, all variables include grid_mapping attribute, and corresponding CRS variable (`spatial_ref`). L1c files are correctly geolocated by QGIS (even if lat/lon variables are removed)

**Note** - we could consider making lat/lon calculations optional, this would further reduce processing time if later processing steps will not require lat/lon anyway.

### Other
Minor updates so I can convert some old landsat scenes I had locally:
* Fix support for collection 2 Level 1 data
* Add parser for ODL format metadata (if processing from a MTL.txt rather than MTL.xml file)



