### PR TITLE
support #6 scale/offset int16 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Where:
 
 ## Command line options
 
-| option                                     | description                                                                                                                             | example                                                                                                 |
-|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| --bands                                    | provide a list of bands to import                                                                                                       | --bands B2 B3 B4                                                                                        |
- | --include-angles                           | include angle data                                                                                                                      | --include-angles                                                                                        |
- | --output-file-pattern                      | specify a pattern for naming the output file                                                                                            | default is --output-file-pattern {Y}{m}{d}{H}{M}{S}-NCEO-{level}-{product}-v{collection:0.1f}-fv01.0.nc |
- | --min-lat, --max-lat, --min-lon, --max-lon | define a bounding box for importing the scene                                                                                           | --min-lat 50 --max-lat 50.5 --min-lon -0.5 --max-lon 0                                                  |
- | --limit                                    | when processing an input folder, stop after processing this many scenes                                                                 | --limit 5                                                                                               |
- | --export-optical-as                        | choose how to import optical data, one of "corrected_reflectance" (default), "reflectance", "radiance"                                  | --export-optical-as "radiance"                                                                          |
- | --export-int16                             | store a band using int16 values, using the provided the band name, scale factor and offset.  This option needs to be used for each band | --export-int16 B4 0.001 0                                                                               |
+| option                                                                 | description                                                                                                                                                                    |
+|------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --bands BANDS                                                          | List of bands to process <br> example: **--bands B2 B3 B4**                                                                                                                    |
+| --include-angles                                                       | include angle data                                                                                                                                                             |
+| --output-file-pattern PATTERN                                          | specify a pattern for naming the output file.  <br>The default is equivalent to --output-file-pattern "{Y}{m}{d}{H}{M}{S}-NCEO-{level}-{product}-v{collection:0.1f}-fv01.0.nc" |
+| --min-lat LAT <br> --max-lat LAT <br> --min-lon LON <br> --max-lon LON | define a bounding box in decimal degrees for importing the scene <br>example: **--min-lat 50 --max-lat 50.5 --min-lon -0.5 --max-lon 0**                                       |
+| --limit N                                                              | Only process the first N scenes found                                                                                                                                          |
+| --export-optical-as FORMAT                                             | choose how to import optical data as "corrected_reflectance",  "reflectance" or "radiance".  <br>example: **--export-optical-as radiance**                                     |                                                          
+| --export-int16 BAND SCALE OFFSET                                       | store a band using int16 values, using the provided the band name, scale factor and offset. <br>example: **--export-int16 B4 0.001 0**                                         |
 
 The `--export-int16` option can be very useful in compressing the output data.  However, the tool will check that the values within the band lie within the range that can be safely compressed and if not, will disable compression, displaying the following message
 
@@ -74,10 +74,10 @@ https://www.usgs.gov/landsat-missions/landsat-collection-2-known-issues
 
 | version | changes                                                                                |
 |---------|----------------------------------------------------------------------------------------|
- | 0.0.1   | initial version                                                                        |
- | 0.0.2   | add support for Landsat 7                                                              |
- | 0.0.3   | rename `--export_optical_as` to `--export-optical-as`, remove `--offset` and `--batch` |
- | 0.0.4   | add `--export-int16`                                                                   |
+| 0.0.1   | initial version                                                                        |
+| 0.0.2   | add support for Landsat 7                                                              |
+| 0.0.3   | rename `--export_optical_as` to `--export-optical-as`, remove `--offset` and `--batch` |
+| 0.0.4   | add `--export-int16`                                                                   |
 
 
 

--- a/README.md
+++ b/README.md
@@ -37,20 +37,34 @@ Where:
 
 ## Command line options
 
-| option        | description                                                                                            | example                                                                                                 |
-| ------------- |--------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| --bands       | provide a list of bands to import                                                                      | --bands B2 B3 B4                                                                                        |
- | --include-angles | include angle data                                                                                     | --include-angles                                                                                        |
- | --output-file-pattern | specify a pattern for naming the output file                                                           | default is --output-file-pattern {Y}{m}{d}{H}{M}{S}-NCEO-{level}-{product}-v{collection:0.1f}-fv01.0.nc |
- | --min-lat, --max-lat, --min-lon, --max-lon | define a bounding box for importing the scene                                                          | --min-lat 50 --max-lat 50.5 --min-lon -0.5 --max-lon 0 |
- | --limit | when processing an input folder, stop after processing this many scenes                                | --limit 5 |
- | --export-optical-as | choose how to import optical data, one of "corrected_reflectance" (default), "reflectance", "radiance" | --export-optical-as "radiance" |
+| option                                     | description                                                                                                                             | example                                                                                                 |
+|--------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| --bands                                    | provide a list of bands to import                                                                                                       | --bands B2 B3 B4                                                                                        |
+ | --include-angles                           | include angle data                                                                                                                      | --include-angles                                                                                        |
+ | --output-file-pattern                      | specify a pattern for naming the output file                                                                                            | default is --output-file-pattern {Y}{m}{d}{H}{M}{S}-NCEO-{level}-{product}-v{collection:0.1f}-fv01.0.nc |
+ | --min-lat, --max-lat, --min-lon, --max-lon | define a bounding box for importing the scene                                                                                           | --min-lat 50 --max-lat 50.5 --min-lon -0.5 --max-lon 0                                                  |
+ | --limit                                    | when processing an input folder, stop after processing this many scenes                                                                 | --limit 5                                                                                               |
+ | --export-optical-as                        | choose how to import optical data, one of "corrected_reflectance" (default), "reflectance", "radiance"                                  | --export-optical-as "radiance"                                                                          |
+ | --export-int16                             | store a band using int16 values, using the provided the band name, scale factor and offset.  This option needs to be used for each band | --export-int16 B4 0.001 0                                                                               |
+
+The `--export-int16` option can be very useful in compressing the output data.  However, the tool will check that the values within the band lie within the range that can be safely compressed and if not, will disable compression, displaying the following message
+
+```
+$ landsat_importer outputs imported --export-int16 B2 0.001 0 --export-int16 B3 0.001 0 --export-int16 B4 0.001 0
+NFO:main:Found 1 scenes to process
+INFO:main:Processing 0: outputs/LC08_L1TP_209048_20250131_20250208_02_T1_MTL.xml -> imported
+...
+WARNING:Netcdf4Exporter:Band B2 requested int16 encoding using (scale=1e-05,offset=0.0) would overflow (data range=(0.11235591024160385,0.5257744789123535), encoded_range=(-0.32767,0.32767) and is not enabled
+INFO:Netcdf4Exporter:Netcdf4 Export complete to imported/20250131115127-NCEO-L1C-Landsat8-v2.0-fv01.0.nc
+```
+
+A safe encoding for reflectance bands would be (scale_factor=0.001,offset=0) retaining 3 decimal places of accuracy.
 
 ## Usage in conjunction with the `usgs` and `usgs-download` tools
 
 The [USGS tools](https://github.com/surftemp/usgs) can be used to locate and download Landsat Imagery.  
 
-An [example script](test/download_and_import.sh) that demonstrates using usgs to download imagery and then landsat_importer to decode and convert them to netcdf4.
+An [example script](test/download_and_import.sh) that demonstrates using the USGS tools to download imagery and then landsat_importer to decode and convert them to netcdf4.
 
 ## Known issues
 
@@ -58,11 +72,12 @@ https://www.usgs.gov/landsat-missions/landsat-collection-2-known-issues
 
 ## Version History
 
-| version | changes |
-| ------- | ------- |
- | 0.0.1  | initial version |
- | 0.0.2  | add support for Landsat 7 |
- | 0.0.3  | rename `--export_optical_as` to `--export-optical-as`, remove `--offset` and `--batch` |
+| version | changes                                                                                |
+|---------|----------------------------------------------------------------------------------------|
+ | 0.0.1   | initial version                                                                        |
+ | 0.0.2   | add support for Landsat 7                                                              |
+ | 0.0.3   | rename `--export_optical_as` to `--export-optical-as`, remove `--offset` and `--batch` |
+ | 0.0.4   | add `--export-int16`                                                                   |
 
 
 

--- a/src/landsat_importer/__init__.py
+++ b/src/landsat_importer/__init__.py
@@ -1,1 +1,1 @@
-VERSION="0.0.3"
+VERSION="0.0.4"

--- a/src/landsat_importer/main.py
+++ b/src/landsat_importer/main.py
@@ -65,6 +65,8 @@ def main():
 
     parser.add_argument("--limit", type=int, help="process only this many scenes", default=None)
 
+    parser.add_argument("--export-int16", nargs=3, metavar=("BAND","OFFSET","SCALE"), action="append", help="export band as int16 with offset and scale", default=[])
+
     args = parser.parse_args()
 
     from landsat_importer.processor import Processor
@@ -89,6 +91,12 @@ def main():
     processed = 0
     limit = args.limit
 
+    export_scale_offset = {}
+    for export_scale in args.export_int16:
+        band = export_scale[0]
+        scale = float(export_scale[1])
+        offset = float(export_scale[2])
+        export_scale_offset[band] = (scale,offset)
 
     for input_path in input_paths:
 
@@ -127,7 +135,8 @@ def main():
 
             p.process(target_bands)
             p.export(output_file_path, include_angles=args.include_angles, min_lat=args.min_lat, min_lon=args.min_lon,
-                     max_lat=args.max_lat, max_lon=args.max_lon, inject_metadata=inject_metadata)
+                     max_lat=args.max_lat, max_lon=args.max_lon, inject_metadata=inject_metadata,
+                     export_scale_offset=export_scale_offset)
 
         except Exception as ex:
             logger.exception(f"Processing failed for {input_path}: "+str(ex))

--- a/src/landsat_importer/netcdf4_exporter.py
+++ b/src/landsat_importer/netcdf4_exporter.py
@@ -175,8 +175,7 @@ class Netcdf4Exporter:
                         self.logger.warning(f"Band {band} requested int16 encoding using (scale={scale},offset={offset}) would overflow (data range=({data_min},{data_max}), encoded_range=({min_encodable_value},{max_encodable_value}) and is not enabled")
                         dataset[band].encoding.update({'dtype': 'float32'})
                     else:
-                        dataset[band].encoding.update({'scale_factor': scale, 'add_offset': offset, 'dtype': 'int16', '_FillValue':-32768})
-
+                        dataset[band].encoding.update({'scale_factor': np.float32(scale), 'add_offset': np.float32(offset), 'dtype': 'int16', '_FillValue':-32768})
                 else:
                     dataset[band].encoding.update({'dtype':'float32'})
 

--- a/src/landsat_importer/netcdf4_exporter.py
+++ b/src/landsat_importer/netcdf4_exporter.py
@@ -61,7 +61,7 @@ class Netcdf4Exporter:
         self.logger = logging.getLogger("Netcdf4Exporter")
 
 
-    def export(self, input_path, dataset, bands, to_path, history="", add_latlon=True, geo_type='float32'):
+    def export(self, input_path, dataset, bands, to_path, history="", add_latlon=True, geo_type='float32', export_scale_offset={}):
         """
         Export an imported scene
 
@@ -73,6 +73,7 @@ class Netcdf4Exporter:
             history: string to supply the processing history to add to global metadata
             add_latlon: calculate and store per-pixel latitude longitude values
             geo_type: storage type for geolocation (x/y and lat/lon coordinates)
+            export_scale_offset: dictionary mapping from BAND to (scale,offset) - encode this band as (signed) int16
         """
         dataset = dataset.expand_dims('time')
         dataset = dataset.rio.write_coordinate_system()
@@ -162,7 +163,22 @@ class Netcdf4Exporter:
             if self.landsat_metadata.is_integer(band):
                 dataset[band].encoding.update({'dtype': 'int32', "_FillValue": -999})
             else:
-                dataset[band].encoding.update({'dtype':'float32'})
+                if band in export_scale_offset:
+                    # int16 encoding is requested
+                    (scale,offset) = export_scale_offset[band]
+                    # only use int16 encoding if safe to do so
+                    min_encodable_value = ( -32767 * scale ) + offset
+                    max_encodable_value = ( 32767 * scale ) + offset
+                    data_min = dataset[band].min(skipna=True).item()
+                    data_max = dataset[band].max(skipna=True).item()
+                    if data_min < min_encodable_value or data_max > max_encodable_value:
+                        self.logger.warning(f"Band {band} requested int16 encoding using (scale={scale},offset={offset}) would overflow (data range=({data_min},{data_max}), encoded_range=({min_encodable_value},{max_encodable_value}) and is not enabled")
+                        dataset[band].encoding.update({'dtype': 'float32'})
+                    else:
+                        dataset[band].encoding.update({'scale_factor': scale, 'add_offset': offset, 'dtype': 'int16', '_FillValue':-32768})
+
+                else:
+                    dataset[band].encoding.update({'dtype':'float32'})
 
             dataset[band].encoding.update(ecomp)
 

--- a/src/landsat_importer/processor.py
+++ b/src/landsat_importer/processor.py
@@ -255,7 +255,7 @@ class Processor:
         return self.landsat_metadata
 
     def export(self, output_path, include_angles=False, history="",
-               min_lat=None, min_lon=None, max_lat=None, max_lon=None, inject_metadata={}):
+               min_lat=None, min_lon=None, max_lat=None, max_lon=None, inject_metadata={}, export_scale_offset={}):
         """
         Export the regridded scene
 
@@ -268,6 +268,7 @@ class Processor:
             max_lat: clip exported data to bounding box
             max_lon: clip exported data to bounding box
             inject_metadata: dictionary to supply global metadata to add to exported file
+            export_scale_offset: dictionary mapping from BAND to (scale,offset) - encode this band as (signed) int16
         """
         self.logger.info("Exporting output grid to file %s" % output_path)
 
@@ -313,4 +314,4 @@ class Processor:
             dataset = self.dataset
 
         exporter.export(input_path=self.input_path, dataset=dataset, bands=self.target_bands,
-                        history=history,to_path=output_path)
+                        history=history,to_path=output_path, export_scale_offset=export_scale_offset)

--- a/test/download_and_import.sh
+++ b/test/download_and_import.sh
@@ -16,7 +16,16 @@ usgs_download --filename scenes.csv --output-folder outputs --file-suffixes B2.T
 
 mamba deactivate
 
-# import the scenes
+# import the scenes using landsat_importer
 mamba activate landsat_importer_env
 
 landsat_importer outputs imported
+
+# optional - make true colour plots from the imported scenes (see https://github.com/surftemp/netcdf_explorer for installation details)
+# add the scene time to the plot
+
+mamba deactivate
+
+mamba activate netcdfexplorer_env
+
+bigplot --input-path imported/* --input-variable B4 B3 B2 --attrs acquisition_time --output-path plots

--- a/test/download_and_import.sh
+++ b/test/download_and_import.sh
@@ -1,31 +1,24 @@
 #!/bin/bash
 
-mamba deactivate
 mamba activate usgs_env
 
-export USGS_USERNAME=<username>
-export USGS_TOKEN=<token>
+export USGS_USERNAME=<USERNAME>
+export USGS_TOKEN=<TOKEN>
 
-# search for scenes in a region and time period of interest
+# search for scenes in a region and time period of interest.  This should find 4 scenes.
 usgs search-create LANDSAT_OT_C2_L1 search.json \
-      --noninteractive --lat-min -20.91 --lon-min 150.83 --lat-max -20.68 --lon-max 151.16 --start-date 2025-01-01 --end-date 2025-01-31 --max-cloud-cover 10
+      --noninteractive --lat-min -20.91 --lon-min 150.83 --lat-max -20.68 --lon-max 151.16 --start-date 2025-01-01 --end-date 2025-03-31 --max-cloud-cover 10
 usgs search-run search.json > scenes.csv
 
 # download the scenes
-usgs_download --filename scenes.csv --output-folder outputs --file-suffixes B2.TIF B3.TIF B4.TIF .XML
+usgs_download --filename scenes.csv --output-folder outputs --file-suffixes QA_PIXEL.TIF B2.TIF B3.TIF B4.TIF .XML
 
 mamba deactivate
 
 # import the scenes using landsat_importer
 mamba activate landsat_importer_env
 
-landsat_importer outputs imported
-
-# optional - make true colour plots from the imported scenes (see https://github.com/surftemp/netcdf_explorer for installation details)
-# add the scene time to the plot
+# use scale of 0.001 and offset 0 for B2/B3/B4
+landsat_importer outputs imported --export-int16 B2 0.001 0 --export-int16 B3 0.001 0 --export-int16 B4 0.001 0
 
 mamba deactivate
-
-mamba activate netcdfexplorer_env
-
-bigplot --input-path imported/* --input-variable B4 B3 B2 --attrs acquisition_time --output-path plots


### PR DESCRIPTION
This PR adds the ability to request that float data is encoded as int16, leading to smaller output files 

The README has more details, but an example would be

```
landsat_importer outputs imported --export-int16 B2 0.001 0 --export-int16 B3 0.001 0 --export-int16 B4 0.001 0
```

We request that bands B2, B3 and B4 be encoded as (signed) int16 values using scale_factor 0.001 and offset 0

This code change will issue a warning and disable int16 export if the values in the data would overflow the encoded int16 representation.
